### PR TITLE
26. Corrected Warning in various files

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,9 +2,26 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="02ea263a-c668-475d-b0f3-2806259edb1f" name="Default" comment="">
-      <change beforePath="$PROJECT_DIR$/DevTracker.xlsx" afterPath="$PROJECT_DIR$/DevTracker.xlsx" />
-      <change beforePath="$PROJECT_DIR$/README.md" afterPath="$PROJECT_DIR$/README.md" />
-      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/@theme/components/tiny-mce/tiny-mce.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/@theme/components/tiny-mce/tiny-mce.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/@core/core.module.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/@core/core.module.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-advanced-pie.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-advanced-pie.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-pie.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-pie.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/echarts/echarts.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/echarts/echarts.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/components/tree/tree.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/components/tree/tree.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.module.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.module.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity-chart/electricity-chart.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity-chart/electricity-chart.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/solar/solar.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/solar/solar.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic-chart.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic-chart.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/ckeditor/ckeditor.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/ckeditor/ckeditor.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/editors.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/editors.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/tiny-mce/tiny-mce.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/tiny-mce/tiny-mce.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-inputs/form-inputs.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-inputs/form-inputs.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-layouts/form-layouts.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-layouts/form-layouts.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/forms.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/forms.component.ts" />
+      <change beforePath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts" afterPath="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts" />
     </list>
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="TRACKING_ENABLED" value="true" />
@@ -15,25 +32,38 @@
   </component>
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-      <file leaf-file-name="README.md" pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/README.md">
-          <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
-            <state split_layout="SPLIT">
-              <first_editor relative-caret-position="0">
-                <caret line="0" column="20" lean-forward="false" selection-start-line="0" selection-start-column="20" selection-end-line="0" selection-end-column="20" />
-                <folding />
-              </first_editor>
-              <second_editor />
+      <file leaf-file-name="electricity-chart.component.ts" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity-chart/electricity-chart.component.ts">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="498">
+              <caret line="181" column="14" lean-forward="true" selection-start-line="181" selection-start-column="14" selection-end-line="181" selection-end-column="14" />
+              <folding>
+                <element signature="e#0#68#0" expanded="true" />
+              </folding>
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="tiny-mce.component.ts" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/@theme/components/tiny-mce/tiny-mce.component.ts">
+      <file leaf-file-name="tree.component.ts" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/components/tree/tree.component.ts">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="345">
-              <caret line="23" column="11" lean-forward="true" selection-start-line="23" selection-start-column="11" selection-end-line="23" selection-end-column="11" />
-              <folding />
+            <state relative-caret-position="68">
+              <caret line="4" column="16" lean-forward="false" selection-start-line="4" selection-start-column="16" selection-end-line="4" selection-end-column="16" />
+              <folding>
+                <element signature="e#0#42#0" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="temperature-dragger.component.ts" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="146">
+              <caret line="144" column="62" lean-forward="false" selection-start-line="144" selection-start-column="62" selection-end-line="144" selection-end-column="62" />
+              <folding>
+                <element signature="e#0#137#0" expanded="true" />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -56,24 +86,6 @@
   <component name="IdeDocumentHistory">
     <option name="CHANGED_PATHS">
       <list>
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.html" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic-chart.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/weather/weather.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.component.html" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/tables/smart-table/smart-table.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/tables/tables.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/action-groups/action-groups.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/block-level-buttons/block-level-buttons.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/button-groups/button-groups.component.html" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/button-groups/button-groups.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/default-buttons/default-buttons.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/dropdown-buttons/dropdown-button.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/icon-buttons/icon-buttons.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/labeled-actions-group/labeled-actions-group.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/shape-buttons/shape-buttons.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/size-buttons/size-buttons.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/buttons.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/buttons.component.html" />
@@ -85,11 +97,9 @@
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/tabs/tabs.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/typography/typography.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/ui-features.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/maps.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/leaflet/leaflet.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/gmaps/gmaps.component.ts" />
-        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/chartjs/chartjs-multiple-xaxis.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/chartjs/chartjs-pie.component.ts" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/chartjs/chartjs-radar.component.ts" />
@@ -107,6 +117,26 @@
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/echarts/echarts.component.html" />
         <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/@theme/components/tiny-mce/tiny-mce.component.ts" />
         <option value="$PROJECT_DIR$/README.md" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.module.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic-chart.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-pie.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-advanced-pie.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/echarts/echarts.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/editors.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-inputs/form-inputs.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-layouts/form-layouts.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/forms.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/tiny-mce/tiny-mce.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/ckeditor/ckeditor.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/@core/core.module.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/solar/solar.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity-chart/electricity-chart.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/components/tree/tree.component.ts" />
+        <option value="$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts" />
       </list>
     </option>
   </component>
@@ -121,7 +151,7 @@
   </component>
   <component name="ProjectFrameBounds">
     <option name="x" value="3" />
-    <option name="width" value="968" />
+    <option name="width" value="1184" />
     <option name="height" value="732" />
   </component>
   <component name="ProjectView">
@@ -203,7 +233,7 @@
               <item name="webapp" type="462c0819:PsiDirectoryNode" />
               <item name="app" type="462c0819:PsiDirectoryNode" />
               <item name="ngx-admin" type="462c0819:PsiDirectoryNode" />
-              <item name="@theme" type="462c0819:PsiDirectoryNode" />
+              <item name="@core" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="Pirate-Castle" type="b2602c69:ProjectViewProjectNode" />
@@ -214,8 +244,7 @@
               <item name="webapp" type="462c0819:PsiDirectoryNode" />
               <item name="app" type="462c0819:PsiDirectoryNode" />
               <item name="ngx-admin" type="462c0819:PsiDirectoryNode" />
-              <item name="@theme" type="462c0819:PsiDirectoryNode" />
-              <item name="components" type="462c0819:PsiDirectoryNode" />
+              <item name="pages" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
               <item name="Pirate-Castle" type="b2602c69:ProjectViewProjectNode" />
@@ -226,9 +255,35 @@
               <item name="webapp" type="462c0819:PsiDirectoryNode" />
               <item name="app" type="462c0819:PsiDirectoryNode" />
               <item name="ngx-admin" type="462c0819:PsiDirectoryNode" />
-              <item name="@theme" type="462c0819:PsiDirectoryNode" />
-              <item name="components" type="462c0819:PsiDirectoryNode" />
-              <item name="tiny-mce" type="462c0819:PsiDirectoryNode" />
+              <item name="pages" type="462c0819:PsiDirectoryNode" />
+              <item name="dashboard" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="Pirate-Castle" type="b2602c69:ProjectViewProjectNode" />
+              <item name="Pirate-Castle" type="462c0819:PsiDirectoryNode" />
+              <item name="barbican" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="webapp" type="462c0819:PsiDirectoryNode" />
+              <item name="app" type="462c0819:PsiDirectoryNode" />
+              <item name="ngx-admin" type="462c0819:PsiDirectoryNode" />
+              <item name="pages" type="462c0819:PsiDirectoryNode" />
+              <item name="dashboard" type="462c0819:PsiDirectoryNode" />
+              <item name="temperature" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="Pirate-Castle" type="b2602c69:ProjectViewProjectNode" />
+              <item name="Pirate-Castle" type="462c0819:PsiDirectoryNode" />
+              <item name="barbican" type="462c0819:PsiDirectoryNode" />
+              <item name="src" type="462c0819:PsiDirectoryNode" />
+              <item name="main" type="462c0819:PsiDirectoryNode" />
+              <item name="webapp" type="462c0819:PsiDirectoryNode" />
+              <item name="app" type="462c0819:PsiDirectoryNode" />
+              <item name="ngx-admin" type="462c0819:PsiDirectoryNode" />
+              <item name="pages" type="462c0819:PsiDirectoryNode" />
+              <item name="dashboard" type="462c0819:PsiDirectoryNode" />
+              <item name="temperature" type="462c0819:PsiDirectoryNode" />
+              <item name="temperature-dragger" type="462c0819:PsiDirectoryNode" />
             </path>
           </expand>
           <select />
@@ -357,15 +412,15 @@
       <option name="presentableId" value="Default" />
       <updated>1518306717446</updated>
       <workItem from="1518306723866" duration="3755000" />
-      <workItem from="1518317998556" duration="30755000" />
+      <workItem from="1518317998556" duration="41379000" />
     </task>
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="34510000" />
+    <option name="totallyTimeSpent" value="45134000" />
   </component>
   <component name="ToolWindowManager">
-    <frame x="3" y="0" width="968" height="732" extended-state="0" />
+    <frame x="3" y="0" width="1184" height="732" extended-state="0" />
     <editor active="true" />
     <layout>
       <window_info id="Palette" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
@@ -377,11 +432,11 @@
       <window_info id="Maven Projects" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
-      <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.28709677" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
+      <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.28709677" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Capture Tool" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="TypeScript" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
       <window_info id="Designer" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.2552521" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.20804794" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="Database" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32903227" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
@@ -437,169 +492,6 @@
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/default-buttons/default-buttons.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="34" lean-forward="true" selection-start-line="3" selection-start-column="34" selection-end-line="3" selection-end-column="34" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/default-buttons/default-buttons.component.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-564">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/dropdown-buttons/dropdown-button.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/hero-buttons/hero-buttons.component.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/icon-buttons/icon-buttons.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/labeled-actions-group/labeled-actions-group.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/labeled-actions-group/labeled-actions-group.component.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/shape-buttons/shape-buttons.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/size-buttons/size-buttons.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/buttons.component.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="323">
-          <caret line="19" column="27" lean-forward="false" selection-start-line="19" selection-start-column="27" selection-end-line="19" selection-end-column="27" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/buttons.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/buttons/buttons.module.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding>
-            <element signature="e#0#41#0" expanded="false" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/grid/grid.component.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/grid/grid.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/icons/icons.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/modals/modal/modal.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-237">
-          <caret line="4" column="16" lean-forward="false" selection-start-line="4" selection-start-column="16" selection-end-line="4" selection-end-column="16" />
-          <folding>
-            <element signature="e#0#42#0" expanded="false" />
-            <marker date="1518381200086" expanded="true" signature="186:369" ph="..." />
-            <marker date="1518381200086" expanded="true" signature="294:358" ph="..." />
-            <marker date="1518381200086" expanded="false" signature="329:336" ph="×" />
-            <marker date="1518381200086" expanded="true" signature="398:434" ph="..." />
-            <marker date="1518381200086" expanded="true" signature="465:566" ph="..." />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/modals/modals.component.html">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="0">
-          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/modals/modals.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="102">
-          <caret line="6" column="16" lean-forward="false" selection-start-line="6" selection-start-column="16" selection-end-line="6" selection-end-column="16" />
-          <folding>
-            <element signature="e#0#42#0" expanded="false" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/search-fields/search-fields.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="18" lean-forward="false" selection-start-line="3" selection-start-column="18" selection-end-line="3" selection-end-column="18" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/ui-features/tabs/tabs.component.ts">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="32">
@@ -617,22 +509,6 @@
           <caret line="4" column="16" lean-forward="false" selection-start-line="4" selection-start-column="16" selection-end-line="4" selection-end-column="16" />
           <folding>
             <element signature="e#0#53#0" expanded="false" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="68">
-          <caret line="4" column="15" lean-forward="false" selection-start-line="4" selection-start-column="15" selection-end-line="4" selection-end-column="16" />
-          <folding>
-            <element signature="e#0#53#0" expanded="false" />
-            <marker date="1518381480406" expanded="true" signature="227:898" ph="..." />
-            <marker date="1518381480406" expanded="true" signature="250:780" ph="..." />
-            <marker date="1518381480406" expanded="true" signature="349:756" ph="..." />
-            <marker date="1518381480406" expanded="true" signature="419:578" ph="..." />
-            <marker date="1518381480406" expanded="true" signature="631:741" ph="..." />
-            <marker date="1518381480406" expanded="true" signature="813:883" ph="..." />
           </folding>
         </state>
       </provider>
@@ -685,16 +561,6 @@
           <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding>
             <element signature="e#0#41#0" expanded="false" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="68">
-          <caret line="4" column="16" lean-forward="false" selection-start-line="4" selection-start-column="16" selection-end-line="4" selection-end-column="16" />
-          <folding>
-            <element signature="e#0#53#0" expanded="false" />
           </folding>
         </state>
       </provider>
@@ -911,6 +777,36 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="309">
+          <caret line="23" column="77" lean-forward="false" selection-start-line="23" selection-start-column="77" selection-end-line="23" selection-end-column="77" />
+          <folding>
+            <element signature="e#0#53#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="360">
+          <caret line="22" column="71" lean-forward="false" selection-start-line="22" selection-start-column="71" selection-end-line="22" selection-end-column="71" />
+          <folding>
+            <element signature="e#0#53#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.module.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="205">
+          <caret line="20" column="74" lean-forward="false" selection-start-line="20" selection-start-column="74" selection-end-line="20" selection-end-column="74" />
+          <folding>
+            <element signature="e#0#41#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/README.md">
       <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
         <state split_layout="SPLIT">
@@ -919,6 +815,191 @@
             <folding />
           </first_editor>
           <second_editor />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic-chart.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="174">
+          <caret line="100" column="32" lean-forward="false" selection-start-line="100" selection-start-column="32" selection-end-line="100" selection-end-column="32" />
+          <folding>
+            <element signature="e#0#68#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-pie.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="120">
+          <caret line="15" column="13" lean-forward="true" selection-start-line="15" selection-start-column="13" selection-end-line="15" selection-end-column="13" />
+          <folding>
+            <element signature="e#0#53#0" expanded="true" />
+            <marker date="1518394085404" expanded="true" signature="182:321" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="259">
+          <caret line="507" column="46" lean-forward="false" selection-start-line="507" selection-start-column="46" selection-end-line="507" selection-end-column="46" />
+          <folding>
+            <marker date="1518395716199" expanded="true" signature="219:390" ph="..." />
+            <marker date="1518395716199" expanded="true" signature="289:375" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-advanced-pie.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="219">
+          <caret line="31" column="71" lean-forward="false" selection-start-line="31" selection-start-column="71" selection-end-line="31" selection-end-column="71" />
+          <folding>
+            <element signature="e#0#53#0" expanded="true" />
+            <marker date="1518395827505" expanded="true" signature="200:291" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-inputs/form-inputs.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="51">
+          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-layouts/form-layouts.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="51">
+          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/charts/echarts/echarts.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="51">
+          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="264">
+          <caret line="35" column="7" lean-forward="true" selection-start-line="35" selection-start-column="7" selection-end-line="35" selection-end-column="7" />
+          <folding>
+            <marker date="1518396001383" expanded="true" signature="227:898" ph="..." />
+            <marker date="1518396001383" expanded="true" signature="250:780" ph="..." />
+            <marker date="1518396001383" expanded="true" signature="349:756" ph="..." />
+            <marker date="1518396001383" expanded="true" signature="419:578" ph="..." />
+            <marker date="1518396001383" expanded="true" signature="631:741" ph="..." />
+            <marker date="1518396001383" expanded="true" signature="813:883" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/forms/forms.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="51">
+          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/editors.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="51">
+          <caret line="3" column="16" lean-forward="false" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/ckeditor/ckeditor.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="170">
+          <caret line="10" column="16" lean-forward="true" selection-start-line="10" selection-start-column="16" selection-end-line="10" selection-end-column="16" />
+          <folding>
+            <element signature="e#0#42#0" expanded="true" />
+            <marker date="1518398824052" expanded="true" signature="159:365" ph="..." />
+            <marker date="1518398824052" expanded="true" signature="182:223" ph="..." />
+            <marker date="1518398824052" expanded="true" signature="244:350" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/ckeditor/ckeditor.loader.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/solar/solar.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="458">
+          <caret line="43" column="80" lean-forward="false" selection-start-line="43" selection-start-column="80" selection-end-line="43" selection-end-column="80" />
+          <folding>
+            <element signature="e#0#75#0" expanded="true" />
+            <marker date="1518403277891" expanded="true" signature="293:641" ph="..." />
+            <marker date="1518403277891" expanded="true" signature="378:626" ph="..." />
+            <marker date="1518403277891" expanded="true" signature="434:449" ph="..." />
+            <marker date="1518403277891" expanded="true" signature="476:604" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/@core/core.module.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="436">
+          <caret line="47" column="4" lean-forward="false" selection-start-line="47" selection-start-column="4" selection-end-line="47" selection-end-column="4" />
+          <folding>
+            <element signature="e#0#82#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/editors/tiny-mce/tiny-mce.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="170">
+          <caret line="10" column="8" lean-forward="false" selection-start-line="10" selection-start-column="8" selection-end-line="10" selection-end-column="8" />
+          <folding>
+            <marker date="1518398824121" expanded="true" signature="116:276" ph="..." />
+            <marker date="1518398824121" expanded="true" signature="139:180" ph="..." />
+            <marker date="1518398824121" expanded="true" signature="201:261" ph="..." />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity-chart/electricity-chart.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="498">
+          <caret line="181" column="14" lean-forward="true" selection-start-line="181" selection-start-column="14" selection-end-line="181" selection-end-column="14" />
+          <folding>
+            <element signature="e#0#68#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/components/tree/tree.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="68">
+          <caret line="4" column="16" lean-forward="false" selection-start-line="4" selection-start-column="16" selection-end-line="4" selection-end-column="16" />
+          <folding>
+            <element signature="e#0#42#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="146">
+          <caret line="144" column="62" lean-forward="false" selection-start-line="144" selection-start-column="62" selection-end-line="144" selection-end-column="62" />
+          <folding>
+            <element signature="e#0#137#0" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>

--- a/barbican/src/main/webapp/app/ngx-admin/@core/core.module.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/@core/core.module.ts
@@ -33,17 +33,18 @@ const NB_CORE_PROVIDERS = [
   ],
   declarations: [],
 })
-export class CoreModule {
-  constructor(@Optional() @SkipSelf() parentModule: CoreModule) {
-    throwIfAlreadyLoaded(parentModule, 'CoreModule');
-  }
 
-  static forRoot(): ModuleWithProviders {
-    return <ModuleWithProviders>{
-      ngModule: CoreModule,
-      providers: [
-        ...NB_CORE_PROVIDERS,
-      ],
-    };
-  }
+export class CoreModule {
+    static forRoot(): ModuleWithProviders {
+        return <ModuleWithProviders>{
+            ngModule: CoreModule,
+            providers: [
+                ...NB_CORE_PROVIDERS,
+            ],
+        };
+    }
+    constructor(@Optional() @SkipSelf() parentModule: CoreModule) {
+        throwIfAlreadyLoaded(parentModule, 'CoreModule');
+    }
+
 }

--- a/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-advanced-pie.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-advanced-pie.component.ts
@@ -29,7 +29,7 @@ export class D3AdvancedPieComponent implements OnDestroy {
   themeSubscription: any;
 
   constructor(private theme: NbThemeService) {
-    this.themeSubscription = this.theme.getJsTheme().subscribe(config => {
+    this.themeSubscription = this.theme.getJsTheme().subscribe((config) => {
       const colors: any = config.variables;
       this.colorScheme = {
         domain: [colors.primaryLight, colors.infoLight, colors.successLight, colors.warningLight, colors.dangerLight],

--- a/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-pie.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/charts/d3/d3-pie.component.ts
@@ -24,7 +24,7 @@ export class D3PieComponent implements OnDestroy {
   themeSubscription: any;
 
   constructor(private theme: NbThemeService) {
-    this.themeSubscription = this.theme.getJsTheme().subscribe(config => {
+    this.themeSubscription = this.theme.getJsTheme().subscribe((config) => {
       const colors: any = config.variables;
       this.colorScheme = {
         domain: [colors.primaryLight, colors.infoLight, colors.successLight, colors.warningLight, colors.dangerLight],

--- a/barbican/src/main/webapp/app/ngx-admin/pages/charts/echarts/echarts.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/charts/echarts/echarts.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'ngx-echarts',
+  selector: 'jhi-echarts',
   styleUrls: ['./echarts.component.scss'],
   templateUrl: './echarts.component.html',
 })

--- a/barbican/src/main/webapp/app/ngx-admin/pages/components/tree/tree.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/components/tree/tree.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { TreeModel } from 'ng2-tree';
 
 @Component({
-  selector: 'ngx-tree',
+  selector: 'jhi-tree',
   templateUrl: './tree.component.html',
 })
 export class TreeComponent {

--- a/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.module.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.module.ts
@@ -20,7 +20,6 @@ import { PlayerComponent } from './rooms/player/player.component';
 import { TrafficComponent } from './traffic/traffic.component';
 import { TrafficChartComponent } from './traffic/traffic-chart.component';
 
-
 @NgModule({
   imports: [
     ThemeModule,

--- a/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity-chart/electricity-chart.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity-chart/electricity-chart.component.ts
@@ -41,7 +41,7 @@ export class ElectricityChartComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.themeSubscription = this.theme.getJsTheme().delay(1).subscribe(config => {
+    this.themeSubscription = this.theme.getJsTheme().delay(1).subscribe((config) => {
       const eTheme: any = config.variables.electricity;
 
       this.option = {
@@ -76,7 +76,7 @@ export class ElectricityChartComponent implements AfterViewInit, OnDestroy {
             type: 'category',
             boundaryGap: false,
             offset: 25,
-            data: this.data.map(i => i.label),
+            data: this.data.map((i) => i.label),
             axisTick: {
               show: false,
             },
@@ -155,7 +155,7 @@ export class ElectricityChartComponent implements AfterViewInit, OnDestroy {
                   }]),
                 },
               },
-              data: this.data.map(i => i.value),
+              data: this.data.map((i) => i.value),
             },
 
             {
@@ -178,7 +178,7 @@ export class ElectricityChartComponent implements AfterViewInit, OnDestroy {
                   opacity: 1,
                 },
               },
-              data: this.data.map(i => i.value),
+              data: this.data.map((i) => i.value),
             },
           ],
         };

--- a/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity.component.ts
@@ -21,7 +21,7 @@ export class ElectricityComponent implements OnDestroy {
   constructor(private eService: ElectricityService, private themeService: NbThemeService) {
     this.data = this.eService.getData();
 
-    this.themeSubscription = this.themeService.getJsTheme().subscribe(theme => {
+    this.themeSubscription = this.themeService.getJsTheme().subscribe((theme) => {
       this.currentTheme = theme.name;
     });
   }

--- a/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/solar/solar.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/solar/solar.component.ts
@@ -41,7 +41,7 @@ export class SolarComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit() {
-    this.themeSubscription = this.theme.getJsTheme().delay(1).subscribe(config => {
+    this.themeSubscription = this.theme.getJsTheme().delay(1).subscribe((config) => {
 
       const solarTheme: any = config.variables.solar;
 

--- a/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
@@ -11,11 +11,28 @@ const VIEW_BOX_SIZE = 300;
 })
 export class TemperatureDraggerComponent implements AfterViewInit, OnChanges {
 
-  @ViewChild('svgRoot') svgRoot: ElementRef;
+    off = false;
+    oldValue: number;
 
-  @Input() fillColors: string|string[] = '#2ec6ff';
-  @Input() disableArcColor = '#999999';
-  @Input() bottomAngle = 90;
+    svgControlId = new Date().getTime();
+    scaleFactor = 1;
+    bottomAngleRad = 0;
+    radius = 100;
+    translateXValue = 0;
+    translateYValue = 0;
+    thickness = 6;
+    pinRadius = 10;
+    colors: any = [];
+
+    private static toRad(angle) {
+        return Math.PI * angle / 180;
+    }
+
+    @ViewChild('svgRoot') svgRoot: ElementRef;
+
+    @Input() fillColors: string|string[] = '#2ec6ff';
+    @Input() disableArcColor = '#999999';
+    @Input() bottomAngle = 90;
   @Input() arcThickness = 18; // CSS pixels
   @Input() thumbRadius = 16; // CSS pixels
   @Input() thumbBorder = 3;
@@ -48,19 +65,6 @@ export class TemperatureDraggerComponent implements AfterViewInit, OnChanges {
   onResize(event) {
     this.invalidate();
   }
-
-  off = false;
-  oldValue: number;
-
-  svgControlId = new Date().getTime();
-  scaleFactor = 1;
-  bottomAngleRad = 0;
-  radius = 100;
-  translateXValue = 0;
-  translateYValue = 0;
-  thickness = 6;
-  pinRadius = 10;
-  colors: any = [];
 
   styles = {
     viewBox: '0 0 300 300',
@@ -139,7 +143,6 @@ export class TemperatureDraggerComponent implements AfterViewInit, OnChanges {
 
     this.scaleFactor = svgBoundingRect.width / VIEW_BOX_SIZE || 1;
     this.styles.viewBox = `0 0 ${VIEW_BOX_SIZE} ${svgHeight}`;
-
 
     const circleFactor = this.bottomAngleRad <= Math.PI
       ? ( 2 / (1 + Math.cos(halfAngle)) )
@@ -347,7 +350,4 @@ export class TemperatureDraggerComponent implements AfterViewInit, OnChanges {
     return Math.round(factor * (this.max - this.min) / this.step) * this.step + this.min;
   }
 
-  private static toRad(angle) {
-    return Math.PI * angle / 180;
-  }
 }

--- a/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.ts
@@ -20,7 +20,7 @@ export class TemperatureComponent implements OnDestroy {
   themeSubscription: any;
 
   constructor(private theme: NbThemeService) {
-    this.themeSubscription = this.theme.getJsTheme().subscribe(config => {
+    this.themeSubscription = this.theme.getJsTheme().subscribe((config) => {
       this.colors = config.variables;
     });
   }

--- a/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic-chart.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic-chart.component.ts
@@ -23,7 +23,7 @@ export class TrafficChartComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit() {
-    this.themeSubscription = this.theme.getJsTheme().delay(1).subscribe(config => {
+    this.themeSubscription = this.theme.getJsTheme().delay(1).subscribe((config) => {
 
       const trafficTheme: any = config.variables.traffic;
 
@@ -98,7 +98,7 @@ export class TrafficChartComponent implements AfterViewInit, OnDestroy {
                 color: trafficTheme.shadowLineDarkBg,
               },
             },
-            data: points.map(p => p - 15),
+            data: points.map((p) => p - 15),
           },
           {
             type: 'line',

--- a/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts
@@ -31,7 +31,7 @@ export class TrafficComponent implements OnDestroy {
   themeSubscription: any;
 
   constructor(private themeService: NbThemeService) {
-    this.themeSubscription = this.themeService.getJsTheme().subscribe(theme => {
+    this.themeSubscription = this.themeService.getJsTheme().subscribe((theme) => {
       this.currentTheme = theme.name;
     });
   }

--- a/barbican/src/main/webapp/app/ngx-admin/pages/editors/ckeditor/ckeditor.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/editors/ckeditor/ckeditor.component.ts
@@ -4,7 +4,7 @@ import './ckeditor.loader';
 import 'ckeditor';
 
 @Component({
-  selector: 'ngx-ckeditor',
+  selector: 'jhi-ckeditor',
   template: `
     <nb-card>
       <nb-card-header>

--- a/barbican/src/main/webapp/app/ngx-admin/pages/editors/editors.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/editors/editors.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'ngx-editors',
+  selector: 'jhi-editors',
   template: `
     <router-outlet></router-outlet>
   `,

--- a/barbican/src/main/webapp/app/ngx-admin/pages/editors/tiny-mce/tiny-mce.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/editors/tiny-mce/tiny-mce.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'ngx-tiny-mce-page',
+  selector: 'jhi-tiny-mce-page',
   template: `
     <nb-card>
       <nb-card-header>

--- a/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-inputs/form-inputs.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-inputs/form-inputs.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'ngx-form-inputs',
+  selector: 'jhi-form-inputs',
   styleUrls: ['./form-inputs.component.scss'],
   templateUrl: './form-inputs.component.html',
 })

--- a/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-layouts/form-layouts.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/forms/form-layouts/form-layouts.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'ngx-form-layouts',
+  selector: 'jhi-form-layouts',
   styleUrls: ['./form-layouts.component.scss'],
   templateUrl: './form-layouts.component.html',
 })

--- a/barbican/src/main/webapp/app/ngx-admin/pages/forms/forms.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/forms/forms.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'ngx-form-elements',
+  selector: 'jhi-form-elements',
   template: `
     <router-outlet></router-outlet>
   `,

--- a/barbican/src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts
+++ b/barbican/src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts
@@ -28,7 +28,7 @@ export class BubbleMapComponent implements OnDestroy {
   constructor(private theme: NbThemeService) {
 
     this.themeSubscription = this.theme.getJsTheme()
-      .subscribe(config => {
+      .subscribe((config) => {
 
         const colors = config.variables;
         this.bubbleTheme = config.variables.bubbleMap;
@@ -468,7 +468,7 @@ export class BubbleMapComponent implements OnDestroy {
           },
           tooltip: {
             trigger: 'item',
-            formatter: params => {
+            formatter: (params) => {
               return `${params.name}: ${params.value[2]}`;
             },
           },
@@ -505,7 +505,7 @@ export class BubbleMapComponent implements OnDestroy {
             {
               type: 'scatter',
               coordinateSystem: 'geo',
-              data: this.mapData.map(itemOpt => {
+              data: this.mapData.map((itemOpt) => {
                 return {
                   name: itemOpt.name,
                   value: [


### PR DESCRIPTION
WARNING in ./src/main/webapp/app/ngx-admin/pages/dashboard/dashboard.module.ts
[23, 1]: Consecutive blank lines are forbidden

WARNING in ./src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature.component.ts
[23, 64]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity.component.ts
[24, 71]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic-chart.component.ts
[26, 73]: Parentheses are required around the parameters of an arrow function definition
[101, 30]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/charts/d3/d3-pie.component.ts
[27, 64]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/maps/bubble/bubble-map.component.ts
[31, 18]: Parentheses are required around the parameters of an arrow function definition
[471, 24]: Parentheses are required around the parameters of an arrow function definition
[508, 38]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/charts/d3/d3-advanced-pie.component.ts
[32, 64]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/dashboard/traffic/traffic.component.ts
[34, 71]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/charts/echarts/echarts.component.ts
[4, 13]: The selector of the component "EchartsComponent" should have prefix "jhi" (https://angular.io/styleguide#style-02-07)
WARNING in ./src/main/webapp/app/ngx-admin/pages/editors/editors.component.ts
[4, 13]: The selector of the component "EditorsComponent" should have prefix "jhi" (https://angular.io/styleguide#style-02-07)
WARNING in ./src/main/webapp/app/ngx-admin/pages/forms/form-inputs/form-inputs.component.ts
[4, 13]: The selector of the component "FormInputsComponent" should have prefix "jhi" (https://angular.io/styleguide#style-02-07)

WARNING in ./src/main/webapp/app/ngx-admin/pages/forms/form-layouts/form-layouts.component.ts
[4, 13]: The selector of the component "FormLayoutsComponent" should have prefix "jhi" (https://angular.io/styleguide#style-02-07)
WARNING in ./src/main/webapp/app/ngx-admin/pages/forms/forms.component.ts
[4, 13]: The selector of the component "FormsComponent" should have prefix "jhi" (https://angular.io/styleguide#style-02-07)
WARNING in ./src/main/webapp/app/ngx-admin/pages/editors/tiny-mce/tiny-mce.component.ts
[4, 13]: The selector of the component "TinyMCEComponent" should have prefix "jhi" (https://angular.io/styleguide#style-02-07)
WARNING in ./src/main/webapp/app/ngx-admin/@core/core.module.ts
[41, 3]: Declaration of static method not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
WARNING in ./src/main/webapp/app/ngx-admin/pages/dashboard/solar/solar.component.ts
[44, 73]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/dashboard/electricity/electricity-chart/electricity-chart.component.ts
[44, 73]: Parentheses are required around the parameters of an arrow function definition
[79, 33]: Parentheses are required around the parameters of an arrow function definition
[158, 35]: Parentheses are required around the parameters of an arrow function definition
[181, 35]: Parentheses are required around the parameters of an arrow function definition
WARNING in ./src/main/webapp/app/ngx-admin/pages/components/tree/tree.component.ts
[5, 13]: The selector of the component "TreeComponent" should have prefix "jhi" (https://angular.io/styleguide#style-02-07)
WARNING in ./src/main/webapp/app/ngx-admin/pages/dashboard/temperature/temperature-dragger/temperature-dragger.component.ts
[52, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[53, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[55, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[56, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[57, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[58, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[59, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[60, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[61, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[62, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[63, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[65, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[75, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[76, 3]: Declaration of instance field not allowed after declaration of instance method. Instead, this should come at the beginning of the class/interface.
[350, 3]: Declaration of static method not allowed after declaration of instance method. Instead, this should come after instance fields.
[143, 1]: Consecutive blank lines are forbidden